### PR TITLE
Allow robot to respond to alias in private messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-reload-flowdock",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "Flowdock",
     "url": "https://www.flowdock.com/"

--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -145,7 +145,7 @@ class Flowdock extends Adapter
       botPrefix = "#{@robot.name}: "
       regex = new RegExp("^@#{@bot.userName}(,|\\b)", "i")
       hubotMsg = msg.replace(regex, botPrefix)
-      if !message.flow && !hubotMsg.match(new RegExp("^#{@robot.name}", "i"))
+      if !message.flow && !hubotMsg.match(new RegExp("^#{@robot.name}", "i")) && !hubotMsg.startsWith(@robot.alias)
         hubotMsg = botPrefix + hubotMsg
 
       author.room = message.flow # Many scripts expect author.room to be available


### PR DESCRIPTION
Currently, hubot's behavior is different in DMs than in flows; messages sent using the alias instead of the bot name are ignored.

This PR patches the code that handles private message to NOT prepend robot name to the message if the alias is used.

Bump version. 
